### PR TITLE
Explicate user service tests

### DIFF
--- a/src/services/user/create.duplicate.test.ts
+++ b/src/services/user/create.duplicate.test.ts
@@ -4,6 +4,8 @@ import 'mocha';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 
 import { UserService } from './';
+import { Result } from '../../helpers';
+import { IUserDto } from '../../models';
 
 describe('UserService.create', () => {
   const data = {
@@ -12,6 +14,7 @@ describe('UserService.create', () => {
   };
   const error = { code: "ER_DUP_ENTRY" };
   let createStub: SinonStub;
+  let result: Result<IUserDto>;
   let sandbox: SinonSandbox;
   let saveStub: SinonStub;
   let userService: UserService;
@@ -30,11 +33,17 @@ describe('UserService.create', () => {
   });
 
   describe('is passed a duplicate username', () => {
-    it('should throw a "duplicate" error', async () => {
-      const result = await userService.create(data);
-      assert(!result.isOk);
-      assert.equal(result.error, error.code);
+    it('should run without error', async () => {
+      result = await userService.create(data);
     })
+
+    it('should return a failure result', async () => {
+      assert(!result.isOk);
+    });
+
+    it('should return the correct error code', async () => {
+      assert.equal(result.error, error.code);
+    });
 
     it('should have called `create` with username', async () => {
       assert(createStub.calledOnce);

--- a/src/services/user/create.success.test.ts
+++ b/src/services/user/create.success.test.ts
@@ -4,6 +4,8 @@ import 'mocha';
 import { createSandbox, SinonSandbox, SinonStub } from 'sinon';
 
 import { UserService } from './';
+import { Result } from '../../helpers';
+import { IUserDto } from '../../models';
 
 describe('UserService.create', () => {
   const data = {
@@ -11,6 +13,7 @@ describe('UserService.create', () => {
     token: "token",
   };
   let createStub: SinonStub;
+  let result: Result<IUserDto>;
   let sandbox: SinonSandbox;
   let saveStub: SinonStub;
   let userService: UserService;
@@ -37,12 +40,18 @@ describe('UserService.create', () => {
   });
 
   describe('is passed a valid username', () => {
-    it('should return a correct result', async () => {
-      const result = await userService.create(data);
+    it('should run without error', async () => {
+      result = await userService.create(data);
+    })
+
+    it('should return an ok result', async () => {
       assert(result.isOk);
+    });
+
+    it('should return the correct UserDto', async () => {
       assert.equal(result.value.username, data.username);
       assert.equal(result.value.token, data.token);
-    })
+    });
 
     it('should have called `create` with username', async () => {
       assert(createStub.calledOnce);


### PR DESCRIPTION
This pull request is in response to #12. It takes the tests in `services/user` and splits the `it`s into their atomic pieces. I did not change `create.invalid.test` because it will be removed when #5 is resolved.