### PR TITLE
Impl service errors

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
+export { ServiceError } from './service-error';
 export { TYPES } from './types';

--- a/src/constants/service-error.ts
+++ b/src/constants/service-error.ts
@@ -1,0 +1,4 @@
+export enum ServiceError {
+  Duplicate = "ER_DUP_ENTRY", // This is a TypeORM error code.
+  NotFound = "ER_NOT_FOUND",
+}

--- a/src/controllers/api/user/class.ts
+++ b/src/controllers/api/user/class.ts
@@ -6,7 +6,7 @@ import {
   httpPost,
 } from 'inversify-express-utils';
 
-import { TYPES } from '../../../constants/';
+import { ServiceError, TYPES } from '../../../constants/';
 import { IBaseRequest, IBaseResponse } from '../../interfaces';
 import { IUserDto } from '../../../models';
 import { IUserService } from '../../../services';
@@ -28,7 +28,7 @@ export class UserController implements interfaces.Controller {
     const result = await this.service.create({ username: req.body.username });
     if (result.isOk) {
       res.status(201).json(result.value);
-    } else if (result.error == "ER_DUP_ENTRY") {
+    } else if (result.error === ServiceError.Duplicate) {
       res.status(409).json(`409 - User "${username}" already exists.`);
     } else {
       res.status(500).json("500 - Server error");
@@ -45,7 +45,7 @@ export class UserController implements interfaces.Controller {
     const result = await this.service.findById(id);
     if (result.isOk) {
       res.status(200).json(result.value);
-    } else if (result.error == "ER_NOT_FOUND") {
+    } else if (result.error === ServiceError.NotFound) {
       res.status(404).json(`404 - No user associated with token.`);
     } else {
       res.status(500).json("500 - Server error");

--- a/src/services/user/class.ts
+++ b/src/services/user/class.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'inversify';
 
-import { TYPES } from '../../constants';
+import { ServiceError, TYPES } from '../../constants';
 import { Result } from '../../helpers';
 import { IUserDto } from '../../models';
 import { IUserRepository } from '../../repositories';
@@ -26,7 +26,7 @@ export class UserService {
     if (user) {
       return Result.ok(user.toDto());
     } else {
-      return Result.fail("ER_NOT_FOUND");
+      return Result.fail(ServiceError.NotFound);
     }
   }
 }

--- a/src/services/user/tests/findById.failure.test.ts
+++ b/src/services/user/tests/findById.failure.test.ts
@@ -4,6 +4,7 @@ import 'mocha';
 import { createSandbox, SinonSandbox } from 'sinon';
 
 import { UserService } from '../';
+import { ServiceError } from '../../../constants';
 import { Result } from '../../../helpers';
 import { IUserDto } from '../../../models';
 
@@ -41,7 +42,7 @@ describe('UserService.findById', () => {
     });
 
     it('should return the correct error code', async () => {
-      assert.equal(result.error, "ER_NOT_FOUND");
+      assert.equal(result.error, ServiceError.NotFound);
     });
   });
 }) 


### PR DESCRIPTION
This is in response to #21.

1. I added an `enum` called `ServiceError` in `constants`.
2. I replaced error codes in `controllers/user` and `services/user` with `ServiceError`s.

This both prevents (1) silly bugs arising from error code typos, and (2) the creation of redundant error codes. But it also adds an additional abstraction that a new user will have to decipher. I think the trade off is worth it.

@kunwar97 You said you were interested in working on this, so let me know if you think there's a better way of doing it.